### PR TITLE
fix fugitive commit preview not shown

### DIFF
--- a/autoload/leaderf/commit.vim
+++ b/autoload/leaderf/commit.vim
@@ -50,7 +50,7 @@ function leaderf#commit#CommitPreview(commit) abort
     if !s:CheckFugitive()
         return
     endif
-    let l:object = fugitive#Open('', 0, '', '', [a:commit])[1:]
+    let l:object = fugitive#Open('', 0, '', a:commit)[1:]
     let l:bufnr = bufadd(l:object)
     return [l:bufnr, 0, '']
 endfunction


### PR DESCRIPTION
there might be fugitive api update, I need to use this batch to let commit preview shown with latest fugitive and leaderf plugin.