### PR TITLE
Add support for --all argument to LeaderfBranch command

### DIFF
--- a/plugin/leaderf-git.vim
+++ b/plugin/leaderf-git.vim
@@ -14,6 +14,7 @@ let g:Lf_Extensions = get(g:, 'Lf_Extensions', {})
 let g:Lf_Extensions.branch = {
             \   'source': {'command': function('leaderf#branch#Command')},
             \   'arguments': [
+            \       {'name': ['-a', '--all'], 'nargs': 0},
             \       {'name': ['-v', '--verbose'], 'nargs': 0},
             \       {'name': ['-vv'], 'nargs': 0}
             \   ],


### PR DESCRIPTION
This PR enables the `-a / --all` argument for the `LeaderfBranch` command:
> -a, --all             list both remote-tracking and local branches